### PR TITLE
Removed BrowserModule import

### DIFF
--- a/src/components/ng2-swipe-cards/ng2-swipe-cards.module.ts
+++ b/src/components/ng2-swipe-cards/ng2-swipe-cards.module.ts
@@ -13,9 +13,6 @@ export class HammerConfig extends HammerGestureConfig {
 }
 
 @NgModule({
-  imports: [
-    BrowserModule
-  ],
   declarations: [
     CardComponent,
     TinderCardDirective


### PR DESCRIPTION
This causes apps that already has this imported to break. It's better to not import it and allow the user of the component to import it than vice versa.