### PR TITLE
Export directly from module file.

### DIFF
--- a/public_api.ts
+++ b/public_api.ts
@@ -9,4 +9,4 @@
 /**
  * Entry point for all public APIs of the package.
  */
-export * from './src/ng2-swipe-cards';
+export * from './src/ng2-swipe-cards.module';


### PR DESCRIPTION
Otherwise, ionic builds fail. Fixes #65 